### PR TITLE
Enable specification of machine type

### DIFF
--- a/pybpodgui_api/models/board/board_com.py
+++ b/pybpodgui_api/models/board/board_com.py
@@ -163,7 +163,8 @@ class BoardCom(BoardIO):
             subject_extra=','.join(list(map(lambda x: '"'+str(x)+'"', xt_subject))),
             user_extra=xt_user,
             variables_names=','.join(["'"+var.name+"'" for var in board_task.variables]),
-            bpod_firmware_version=conf.TARGET_BPOD_FIRMWARE_VERSION
+            bpod_firmware_version=conf.TARGET_BPOD_FIRMWARE_VERSION,
+            bpod_machine_type=conf.EMULATOR_BPOD_MACHINE_TYPE,
         )
 
         for var in board_task.variables:

--- a/pybpodgui_api/models/board/run_settings_template.py
+++ b/pybpodgui_api/models/board/run_settings_template.py
@@ -27,6 +27,7 @@ PYBPOD_USER_EXTRA = '{user_extra}'
 
 
 TARGET_BPOD_FIRMWARE_VERSION = '{bpod_firmware_version}'
+EMULATOR_BPOD_MACHINE_TYPE = '{bpod_machine_type}'
 
 #import logging
 #PYBPOD_API_LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
In gui user settines machine type can be specified and overwrite the default settings from pybpod-api.

Fixes the error:
'Error creating state: Punishment. Wire1 is an invalid output name.'

`Close #1 `